### PR TITLE
Added either config in tests, to support astra infra

### DIFF
--- a/packages/collections/src/collections.test.js
+++ b/packages/collections/src/collections.test.js
@@ -56,6 +56,7 @@ describe("AstraJS", () => {
           baseUrl: process.env.STARGATE_BASE_URL,
           username: process.env.STARGATE_USERNAME,
           password: process.env.STARGATE_PASSWORD,
+          debug: true,
         };
       } 
       

--- a/packages/collections/src/collections.test.js
+++ b/packages/collections/src/collections.test.js
@@ -42,12 +42,24 @@ describe("AstraJS", () => {
     const documentId = faker.random.alphaNumeric(8);
 
     before(async () => {
-      const astraClient = await astraCollections.createClient({
-        astraDatabaseId: process.env.ASTRA_DB_ID,
-        astraDatabaseRegion: process.env.ASTRA_DB_REGION,
-        username: process.env.ASTRA_DB_USERNAME,
-        password: process.env.ASTRA_DB_PASSWORD,
-      });
+      let opts;
+      if (process.env.ASTRA_DB_ID) {
+        opts = {
+          astraDatabaseId: process.env.ASTRA_DB_ID,
+          astraDatabaseRegion: process.env.ASTRA_DB_REGION,
+          username: process.env.ASTRA_DB_USERNAME,
+          password: process.env.ASTRA_DB_PASSWORD,
+        };
+      } else if (process.env.STARGATE_BASE_URL) {
+        opts = {
+          authUrl: process.env.STARGATE_AUTH_URL,
+          baseUrl: process.env.STARGATE_BASE_URL,
+          username: process.env.STARGATE_USERNAME,
+          password: process.env.STARGATE_PASSWORD,
+        };
+      } 
+      
+      const astraClient = await astraCollections.createClient(opts);
       testCollection = astraClient.namespace(namespace).collection(collection);
     });
 

--- a/packages/collections/src/collections.test.js
+++ b/packages/collections/src/collections.test.js
@@ -38,7 +38,7 @@ describe("AstraJS", () => {
     // setup test context
     let testCollection = null;
     const namespace = process.env.ASTRA_DB_KEYSPACE;
-    const collection = "test";
+    const collection = "test_" + Math.random().toString(36).replace(/[^a-z]+/g, '');
     const documentId = faker.random.alphaNumeric(8);
 
     before(async () => {
@@ -187,7 +187,7 @@ describe("AstraJS", () => {
     let testCollection = null;
     let stargateClient = null;
     const namespace = process.env.ASTRA_DB_KEYSPACE;
-    const collection = "test";
+    const collection = "test_" + Math.random().toString(36).replace(/[^a-z]+/g, '');
     const documentId = faker.random.alphaNumeric(8);
 
     before(async () => {

--- a/packages/rest/src/rest.js
+++ b/packages/rest/src/rest.js
@@ -44,7 +44,11 @@ const createClient = async (options) => {
   if ((options.astraDatabaseId, options.astraDatabaseRegion)) {
     baseUrl = `https://${options.astraDatabaseId}-${options.astraDatabaseRegion}.apps.astra.datastax.com`;
   } else if (options.baseUrl) {
-    baseUrl = options.baseUrl;
+    if (options.baseUrl.endsWith('/api/rest')) {
+      baseUrl = options.baseUrl.substring(0, options.baseUrl.length - 9);
+    } else {
+      baseUrl = options.baseUrl;
+    }
   }
   if (!baseUrl) {
     throw new Error("@astrajs/rest: baseUrl required for initialization");

--- a/packages/rest/src/rest.js
+++ b/packages/rest/src/rest.js
@@ -111,7 +111,8 @@ const axiosRequest = async (options) => {
       data: response.data.data ? response.data.data : response.data,
     };
   } catch (error) {
-    throw new Error("Request Failed: " + error.message);
+    console.log("Error found:", error)
+    throw new Error(error);
   }
 };
 


### PR DESCRIPTION
Allow Base URL/Auth URL to be used in astra tests, if they are provided. Also, Base URL's that have `/api/rest` tacked onto the end are allowed and will be converted to the expected base URL.

This allows orchestrator combo tests to be run using non-prod base/auth URLs