### PR TITLE
fix: Adjust return value from delete function (#9)

### DIFF
--- a/packages/collections/src/collections.js
+++ b/packages/collections/src/collections.js
@@ -136,7 +136,7 @@ class AstraCollection {
   async delete(path) {
     const response = await this.restClient.delete(`${this.basePath}/${path}`);
     if (response.status === 204) {
-      return response.data;
+      return { documentId: path, deleted: true };
     }
     return null;
   }


### PR DESCRIPTION
closes #9 

Adjusted return-object from `delete`-Function as proposed in #9 